### PR TITLE
issue_64

### DIFF
--- a/src/cpp/h5cpp/datatype/datatype.cpp
+++ b/src/cpp/h5cpp/datatype/datatype.cpp
@@ -55,19 +55,32 @@ namespace hdf5
 	return type;
       }
     };
-    
-    bool is_bool(const Enum & etype){
-      int s = etype.number_of_values();
-      if(s != 2){
+
+    //!
+    //! @brief check if Enum is EBool
+    //!
+    //! @param DataType object
+    //! @return if Enum is EBool flag
+    //!
+    bool is_bool(const Datatype & dtype){
+      if(dtype.get_class() == Class::ENUM){
+	auto etype = datatype::Enum(dtype);
+	int s = etype.number_of_values();
+	if(s != 2){
+	  return false;
+	}
+	if(etype.name(0) != "FALSE"){
+	  return false;
+	}
+	if(etype.name(1) != "TRUE"){
+	  return false;
+	}
+	return true;
+      }
+      else{
 	return false;
       }
-      if(etype.name(0) != "FALSE"){
-	return false;
-      }
-      if(etype.name(1) != "TRUE"){
-	return false;
-      }
-      return true;
+
     }
     
   }
@@ -173,6 +186,11 @@ BOOST_PYTHON_MODULE(_datatype)
       .def("fixed",&String::fixed)
       .staticmethod("fixed");
 
+  class_<Enum, bases<Datatype>>("Enum")
+      .def(init<const Datatype&>())
+    ;
+    
+
   scope current;
 
   current.attr("kUInt8") = hdf5::datatype::create<uint8_t>();
@@ -187,4 +205,8 @@ BOOST_PYTHON_MODULE(_datatype)
   current.attr("kFloat32") = hdf5::datatype::create<float>();
   current.attr("kFloat128") = hdf5::datatype::create<long double>();
   current.attr("kVariableString") = hdf5::datatype::create<std::string>();
+  current.attr("kEBool") = hdf5::datatype::create<hdf5::datatype::EBool>();
+
+  //need some functions
+  def("is_bool",&is_bool);
 }

--- a/src/cpp/h5cpp/datatype/datatype.cpp
+++ b/src/cpp/h5cpp/datatype/datatype.cpp
@@ -25,6 +25,53 @@
 #include <boost/python.hpp>
 #include <h5cpp/hdf5.hpp>
 #include <cstdint>
+#include <h5cpp/datatype/datatype.hpp>
+#include <h5cpp/datatype/enum.hpp>
+
+
+namespace hdf5
+{
+  namespace datatype
+  {
+    //!
+    //! \brief enumeration bool type
+    //!
+    enum EBool : int8_t
+    {
+      FALSE = 0, //!< indicates a false value
+      TRUE = 1   //!< indicates a true value
+    };
+    
+    template<>
+    class TypeTrait<datatype::EBool> {
+    public:
+      using TypeClass = datatype::Enum;
+      using Type = datatype::EBool;
+      
+      static TypeClass create(const Type & = Type()) {
+	auto type = TypeClass::create(Type());
+	type.insert("FALSE", Type::FALSE);
+	type.insert("TRUE", Type::TRUE);
+	return type;
+      }
+    };
+    
+    bool is_bool(const Enum & etype){
+      int s = etype.number_of_values();
+      if(s != 2){
+	return false;
+      }
+      if(etype.name(0) != "FALSE"){
+	return false;
+      }
+      if(etype.name(1) != "TRUE"){
+	return false;
+      }
+      return true;
+    }
+    
+  }
+}
 
 
 BOOST_PYTHON_MODULE(_datatype)

--- a/src/cpp/h5cpp/datatype/datatype.cpp
+++ b/src/cpp/h5cpp/datatype/datatype.cpp
@@ -41,13 +41,13 @@ namespace hdf5
       FALSE = 0, //!< indicates a false value
       TRUE = 1   //!< indicates a true value
     };
-    
+
     template<>
     class TypeTrait<datatype::EBool> {
     public:
       using TypeClass = datatype::Enum;
       using Type = datatype::EBool;
-      
+
       static TypeClass create(const Type & = Type()) {
 	auto type = TypeClass::create(Type());
 	type.insert("FALSE", Type::FALSE);
@@ -80,9 +80,8 @@ namespace hdf5
       else{
 	return false;
       }
-
     }
-    
+
   }
 }
 
@@ -189,7 +188,7 @@ BOOST_PYTHON_MODULE(_datatype)
   class_<Enum, bases<Datatype>>("Enum")
       .def(init<const Datatype&>())
     ;
-    
+
 
   scope current;
 

--- a/src/cpp/h5cpp/numpy/array_factory.cpp
+++ b/src/cpp/h5cpp/numpy/array_factory.cpp
@@ -19,6 +19,7 @@
 //
 // Created on: Feb 31, 2018
 //     Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+//             Jan Kotanski <jan.kotanski@desy.de>
 //
 
 #include "array_factory.hpp"

--- a/src/cpp/h5cpp/numpy/array_factory.cpp
+++ b/src/cpp/h5cpp/numpy/array_factory.cpp
@@ -31,6 +31,8 @@ extern "C"{
 #include<Python.h>
 #include<numpy/arrayobject.h>
 }
+#include <h5cpp/datatype/datatype.hpp>
+#include <h5cpp/datatype/enum.hpp>
 
 namespace {
 
@@ -62,6 +64,23 @@ int get_type_number(const hdf5::datatype::Datatype &datatype)
       return NPY_STRING;
 #endif
     }
+  }
+  else if(datatype.get_class() == Class::ENUM)
+  {
+    auto etype = hdf5::datatype::Enum(datatype);
+
+    int s = etype.number_of_values();
+    if(s != 2){
+      return NPY_INT64;
+    }
+    if(etype.name(0) != "FALSE"){
+      return NPY_INT64;
+    }
+    if(etype.name(1) != "TRUE"){
+      return NPY_INT64;
+    }
+    return NPY_BOOL;
+
   }
   else if(datatype == create<bool>()) return NPY_BOOL;
   else

--- a/src/pninexus/h5cpp/datatype/__init__.py
+++ b/src/pninexus/h5cpp/datatype/__init__.py
@@ -38,6 +38,7 @@ from pninexus.h5cpp._datatype import kEBool
 
 from pninexus.h5cpp._datatype import is_bool
 
+
 class Factory(object):
     """Construct HDF5 datatypes from numpy types
 

--- a/src/pninexus/h5cpp/datatype/__init__.py
+++ b/src/pninexus/h5cpp/datatype/__init__.py
@@ -17,6 +17,7 @@ from pninexus.h5cpp._datatype import Datatype
 from pninexus.h5cpp._datatype import Float
 from pninexus.h5cpp._datatype import Integer
 from pninexus.h5cpp._datatype import String
+from pninexus.h5cpp._datatype import Enum
 
 #
 # Import predefined constant types
@@ -33,14 +34,16 @@ from pninexus.h5cpp._datatype import kFloat64
 from pninexus.h5cpp._datatype import kFloat32
 from pninexus.h5cpp._datatype import kFloat128
 from pninexus.h5cpp._datatype import kVariableString
+from pninexus.h5cpp._datatype import kEBool
 
+from pninexus.h5cpp._datatype import is_bool
 
 class Factory(object):
     """Construct HDF5 datatypes from numpy types
 
     """
 
-    type_map = {"bool": kUInt8,
+    type_map = {"bool": kEBool,
                 "int8": kInt8,
                 "uint8": kUInt8,
                 "int16": kInt16,
@@ -111,6 +114,8 @@ def to_numpy(hdf5_datatype):
         return "float64"
     elif hdf5_datatype == kFloat128:
         return "float128"
+    elif hdf5_datatype == kEBool:
+        return "bool"
     elif isinstance(hdf5_datatype, String):
         if hdf5_datatype.is_variable_length:
             return "object"
@@ -124,4 +129,4 @@ __all__ = [Class, Order, Sign, Norm, Pad, StringPad, Direction,
            CharacterEncoding, Datatype, Float, Integer, String,
            kUInt8, kInt8, kUInt16, kInt16, kUInt32, kInt32, kUInt64,
            kInt64, kFloat64, kFloat32, kFloat128, kVariableString,
-           Factory, kFactory, to_numpy]
+           Factory, kFactory, to_numpy, kEBool, is_bool]

--- a/test/h5cpp_tests/datatype_tests/predefined_type_tests.py
+++ b/test/h5cpp_tests/datatype_tests/predefined_type_tests.py
@@ -25,11 +25,12 @@
 from __future__ import print_function
 import unittest
 from pninexus import h5cpp
-from pninexus.h5cpp.datatype import Float, String, Datatype, Integer
+from pninexus.h5cpp.datatype import Float, String, Datatype, Integer, Enum
 
 
 class PredefinedTypeTests(unittest.TestCase):
 
+    enum_types = (Datatype, Enum)
     float_types = (Datatype, Float)
     int_types = (Datatype, Integer)
     string_types = (Datatype, String)
@@ -136,3 +137,10 @@ class PredefinedTypeTests(unittest.TestCase):
         dtype = h5cpp.datatype.kVariableString
         self.assertTrue(isinstance(dtype, self.string_types))
         self.assertTrue(dtype.is_variable_length)
+
+    def testEBool(self):
+
+        dtype = h5cpp.datatype.kEBool
+        self.assertTrue(isinstance(dtype, self.enum_types))
+        self.assertTrue(h5cpp._datatype.is_bool(dtype))
+        self.assertEqual(dtype.size, 1)


### PR DESCRIPTION
It adds support for Enum Bool types compatible  to `h5py`. 
I hope I the future a part of implementation can be move to `libh5cpp`  (https://github.com/ess-dmsc/h5cpp/pull/358) so c++ developers will not  need to redefine EBool in all their client codes.
