### PR TITLE
Ebool

### DIFF
--- a/src/pninexus/h5cpp/attribute/__init__.py
+++ b/src/pninexus/h5cpp/attribute/__init__.py
@@ -23,6 +23,8 @@ def attribute_write(self, data):
 
     if write_data.dtype.kind == 'U':
         write_data = write_data.astype("S")
+    elif write_data.dtype == 'bool':
+        write_data = write_data.astype("int8")
 
     try:
         self._write(write_data)

--- a/src/pninexus/h5cpp/node/__init__.py
+++ b/src/pninexus/h5cpp/node/__init__.py
@@ -264,9 +264,13 @@ def dataset_write(self, data, selection=None):
     #
     # if the data is a unicode numpy array we have to convert it to a
     # simple string array
+    # else if the data is bool numpy array we have to convert it to a
+    # int array
     #
     if data.dtype.kind == 'U':
         data = data.astype('S')
+    elif data.dtype == 'bool':
+        data = data.astype("int8")
 
     #
     # determine memory datatype and dataspace

--- a/test/h5cpp_tests/node_tests/dataset_io_test.py
+++ b/test/h5cpp_tests/node_tests/dataset_io_test.py
@@ -81,7 +81,6 @@ class DatasetAllIOTests(unittest.TestCase):
         dataset2 = Dataset(self.root, h5cpp.Path("EBoolScalar2"),
                           h5cpp.datatype.kEBool, Scalar())
         dataset.write(True)
-        read = dataset.read()
         self.assertTrue(dataset.read())
         dataset2.write(False)
         self.assertTrue(not dataset2.read())

--- a/test/h5cpp_tests/node_tests/dataset_io_test.py
+++ b/test/h5cpp_tests/node_tests/dataset_io_test.py
@@ -74,6 +74,27 @@ class DatasetAllIOTests(unittest.TestCase):
         read = dataset.read()
         self.assertEqual(read, 23.321)
 
+    def testWriteEBooleanScalar(self):
+
+        dataset = Dataset(self.root, h5cpp.Path("EBoolScalar"),
+                          h5cpp.datatype.kEBool, Scalar())
+        dataset2 = Dataset(self.root, h5cpp.Path("EBoolScalar2"),
+                          h5cpp.datatype.kEBool, Scalar())
+        dataset.write(True)
+        read = dataset.read()
+        self.assertTrue(dataset.read())
+        dataset2.write(False)
+        self.assertTrue(not dataset2.read())
+
+    def testWriteEBoolArray(self):
+
+        data = [True, False, False, True]
+        dataset = Dataset(self.root, h5cpp.Path("EBoolArray"),
+                          h5cpp.datatype.kFloat64, Simple((4, )))
+        dataset.write(data)
+        read = dataset.read()
+        npt.assert_array_equal(read, numpy.array(data))
+
     def testWriteFixedLengthStringScalar(self):
 
         data = "hello world"

--- a/test/h5cpp_tests/node_tests/dataset_io_test.py
+++ b/test/h5cpp_tests/node_tests/dataset_io_test.py
@@ -79,7 +79,7 @@ class DatasetAllIOTests(unittest.TestCase):
         dataset = Dataset(self.root, h5cpp.Path("EBoolScalar"),
                           h5cpp.datatype.kEBool, Scalar())
         dataset2 = Dataset(self.root, h5cpp.Path("EBoolScalar2"),
-                          h5cpp.datatype.kEBool, Scalar())
+                           h5cpp.datatype.kEBool, Scalar())
         dataset.write(True)
         self.assertTrue(dataset.read())
         dataset2.write(False)


### PR DESCRIPTION
It resolves the issue #46 by changing python boolean types to int. The origin of the problem was automatic conversion python bool types to c++ ones.