### PR TITLE
fix FATAL: module compiled as little endian error

### DIFF
--- a/src/cpp/h5cpp/_h5cpp.cpp
+++ b/src/cpp/h5cpp/_h5cpp.cpp
@@ -43,14 +43,17 @@ using namespace boost::python;
 
 
 #if PY_MAJOR_VERSION >= 3
-int
+static void * init_numpy()
+{
+    import_array();
+    return NULL;
+}
 #else 
-void
-#endif
-init_numpy()
+static void init_numpy()
 {
     import_array();
 }
+#endif
 
 std::string path_to_string(const hdf5::Path &self)
 {

--- a/src/cpp/h5cpp/attribute/attribute.cpp
+++ b/src/cpp/h5cpp/attribute/attribute.cpp
@@ -43,14 +43,17 @@ extern "C"{
 #include <h5cpp/datatype/enum.hpp>
 
 #if PY_MAJOR_VERSION >= 3
-int
-#else
-void
-#endif
-init_numpy()
+static void * init_numpy()
+{
+    import_array();
+    return NULL;
+}
+#else 
+static void init_numpy()
 {
     import_array();
 }
+#endif
 
 namespace {
 

--- a/src/cpp/h5cpp/node/nodes.cpp
+++ b/src/cpp/h5cpp/node/nodes.cpp
@@ -36,14 +36,17 @@ extern "C"{
 
 
 #if PY_MAJOR_VERSION >= 3
-int
-#else
-void
-#endif
-init_numpy()
+static void * init_numpy()
+{
+    import_array();
+    return NULL;
+}
+#else 
+static void init_numpy()
 {
     import_array();
 }
+#endif
 
 hdf5::node::Link get_link_by_index(const hdf5::node::LinkView &self,size_t index)
 {

--- a/src/cpp/nexus/nexus.cpp
+++ b/src/cpp/nexus/nexus.cpp
@@ -43,14 +43,17 @@ using namespace boost::python;
 using namespace pni::io;
 
 #if PY_MAJOR_VERSION >= 3
-int
+static void * init_numpy()
+{
+    import_array();
+    return NULL;
+}
 #else 
-void
-#endif
-init_numpy()
+static void init_numpy()
 {
     import_array();
 }
+#endif
 
 
 


### PR DESCRIPTION
fix FATAL: module compiled as little endian, but detected different endianness at runtime from python-pni.  It is mentioned in  #73.
