### PR TITLE
Issue 94: add missing Integer properties

### DIFF
--- a/src/cpp/h5cpp/datatype/datatype.cpp
+++ b/src/cpp/h5cpp/datatype/datatype.cpp
@@ -30,6 +30,15 @@
 #include <h5cpp/datatype/ebool.hpp>
 
 
+const boost::python::list integer_pad(const hdf5::datatype::Integer &self)
+{
+  std::vector<hdf5::datatype::Pad> pad_ = self.pad();
+  boost::python::list padlist;
+  for (auto pd: pad_){
+      padlist.append(pd);
+  }
+  return padlist;
+}
 
 BOOST_PYTHON_MODULE(_datatype)
 {
@@ -60,7 +69,9 @@ BOOST_PYTHON_MODULE(_datatype)
 
   enum_<Order>("Order")
       .value("LE",Order::LE)
-      .value("BE",Order::BE);
+      .value("BE",Order::BE)
+      .value("VAX",Order::VAX)
+      .value("NONE",Order::NONE);
 
   enum_<Sign>("Sign")
       .value("TWOS_COMPLEMENT",Sign::TWOS_COMPLEMENT)
@@ -102,10 +113,23 @@ BOOST_PYTHON_MODULE(_datatype)
       ;
 
 
+  size_t (Integer::*get_precision)() const = &Integer::precision;
+  void (Integer::*set_precision)(size_t) const = &Integer::precision;
+  size_t (Integer::*get_offset)() const = &Integer::offset;
+  void (Integer::*set_offset)(size_t) const = &Integer::offset;
+  Order (Integer::*get_order)() const = &Integer::order;
+  void (Integer::*set_order)(Order) const = &Integer::order;
+  //  const std::vector<Pad> (Integer::*get_pad)() const = &Integer::pad;
+  void (Integer::*set_pad)(Pad,Pad) const = &Integer::pad;
   class_<Integer,bases<Datatype>>("Integer")
       .def(init<const Datatype&>())
       .def("make_signed", &Integer::make_signed)
       .def("is_signed", &Integer::is_signed)
+      .add_property("precision",get_precision,set_precision)
+      .add_property("offset",get_offset,set_offset)
+      .add_property("order",get_order,set_order)
+      .def("pad", integer_pad)
+      .def("make_pad", set_pad)
       ;
 
   class_<Float,bases<Datatype>>("Float")

--- a/test/h5cpp_tests/datatype_tests/predefined_type_tests.py
+++ b/test/h5cpp_tests/datatype_tests/predefined_type_tests.py
@@ -45,6 +45,38 @@ class PredefinedTypeTests(unittest.TestCase):
         dtype.make_signed(True)
         self.assertEqual(dtype.is_signed(), True)
 
+        self.assertEqual(dtype.precision, 8)
+        dtype.precision = 16
+        self.assertEqual(dtype.precision, 16)
+        dtype.precision = 8
+        self.assertEqual(dtype.precision, 8)
+
+        self.assertEqual(dtype.offset, 0)
+        dtype.offset = 2
+        self.assertEqual(dtype.offset, 2)
+        dtype.offset = 0
+        self.assertEqual(dtype.offset, 0)
+
+        order = dtype.order
+        self.assertTrue(dtype.order in [h5cpp.datatype.Order.LE,
+                                        h5cpp.datatype.Order.BE])
+        dtype.order = h5cpp.datatype.Order.BE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.BE)
+        dtype.order = h5cpp.datatype.Order.LE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.LE)
+        dtype.order = order
+
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ZERO)
+        self.assertEqual(mp, h5cpp.datatype.Pad.ZERO)
+        dtype.make_pad(h5cpp.datatype.Pad.ONE,
+                       h5cpp.datatype.Pad.BACKGROUND)
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ONE)
+        self.assertEqual(mp, h5cpp.datatype.Pad.BACKGROUND)
+        dtype.make_pad(h5cpp.datatype.Pad.ZERO,
+                       h5cpp.datatype.Pad.ZERO)
+
     def testInt8(self):
 
         dtype = h5cpp.datatype.kInt8
@@ -53,6 +85,38 @@ class PredefinedTypeTests(unittest.TestCase):
 
         dtype.make_signed(False)
         self.assertEqual(dtype.is_signed(), False)
+
+        self.assertEqual(dtype.precision, 8)
+        dtype.precision = 16
+        self.assertEqual(dtype.precision, 16)
+        dtype.precision = 8
+        self.assertEqual(dtype.precision, 8)
+
+        self.assertEqual(dtype.offset, 0)
+        dtype.offset = 2
+        self.assertEqual(dtype.offset, 2)
+        dtype.offset = 0
+        self.assertEqual(dtype.offset, 0)
+
+        order = dtype.order
+        self.assertTrue(dtype.order in [h5cpp.datatype.Order.LE,
+                                        h5cpp.datatype.Order.BE])
+        dtype.order = h5cpp.datatype.Order.BE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.BE)
+        dtype.order = h5cpp.datatype.Order.LE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.LE)
+        dtype.order = order
+
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ZERO)
+        self.assertEqual(mp, h5cpp.datatype.Pad.ZERO)
+        dtype.make_pad(h5cpp.datatype.Pad.ONE,
+                       h5cpp.datatype.Pad.BACKGROUND)
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ONE)
+        self.assertEqual(mp, h5cpp.datatype.Pad.BACKGROUND)
+        dtype.make_pad(h5cpp.datatype.Pad.ZERO,
+                       h5cpp.datatype.Pad.ZERO)
 
     def testUInt16(self):
 
@@ -64,6 +128,38 @@ class PredefinedTypeTests(unittest.TestCase):
         dtype.make_signed(True)
         self.assertEqual(dtype.is_signed(), True)
 
+        self.assertEqual(dtype.precision, 16)
+        dtype.precision = 12
+        self.assertEqual(dtype.precision, 12)
+        dtype.precision = 16
+        self.assertEqual(dtype.precision, 16)
+
+        self.assertEqual(dtype.offset, 0)
+        dtype.offset = 2
+        self.assertEqual(dtype.offset, 2)
+        dtype.offset = 0
+        self.assertEqual(dtype.offset, 0)
+
+        order = dtype.order
+        self.assertTrue(dtype.order in [h5cpp.datatype.Order.LE,
+                                        h5cpp.datatype.Order.BE])
+        dtype.order = h5cpp.datatype.Order.BE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.BE)
+        dtype.order = h5cpp.datatype.Order.LE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.LE)
+        dtype.order = order
+
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ZERO)
+        self.assertEqual(mp, h5cpp.datatype.Pad.ZERO)
+        dtype.make_pad(h5cpp.datatype.Pad.ONE,
+                       h5cpp.datatype.Pad.BACKGROUND)
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ONE)
+        self.assertEqual(mp, h5cpp.datatype.Pad.BACKGROUND)
+        dtype.make_pad(h5cpp.datatype.Pad.ZERO,
+                       h5cpp.datatype.Pad.ZERO)
+
     def testInt16(self):
 
         dtype = h5cpp.datatype.kInt16
@@ -73,6 +169,38 @@ class PredefinedTypeTests(unittest.TestCase):
 
         dtype.make_signed(False)
         self.assertEqual(dtype.is_signed(), False)
+
+        self.assertEqual(dtype.precision, 16)
+        dtype.precision = 12
+        self.assertEqual(dtype.precision, 12)
+        dtype.precision = 16
+        self.assertEqual(dtype.precision, 16)
+
+        self.assertEqual(dtype.offset, 0)
+        dtype.offset = 2
+        self.assertEqual(dtype.offset, 2)
+        dtype.offset = 0
+        self.assertEqual(dtype.offset, 0)
+
+        order = dtype.order
+        self.assertTrue(dtype.order in [h5cpp.datatype.Order.LE,
+                                        h5cpp.datatype.Order.BE])
+        dtype.order = h5cpp.datatype.Order.BE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.BE)
+        dtype.order = h5cpp.datatype.Order.LE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.LE)
+        dtype.order = order
+
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ZERO)
+        self.assertEqual(mp, h5cpp.datatype.Pad.ZERO)
+        dtype.make_pad(h5cpp.datatype.Pad.ONE,
+                       h5cpp.datatype.Pad.BACKGROUND)
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ONE)
+        self.assertEqual(mp, h5cpp.datatype.Pad.BACKGROUND)
+        dtype.make_pad(h5cpp.datatype.Pad.ZERO,
+                       h5cpp.datatype.Pad.ZERO)
 
     def testUInt32(self):
 
@@ -84,6 +212,38 @@ class PredefinedTypeTests(unittest.TestCase):
         dtype.make_signed(True)
         self.assertEqual(dtype.is_signed(), True)
 
+        self.assertEqual(dtype.precision, 32)
+        dtype.precision = 16
+        self.assertEqual(dtype.precision, 16)
+        dtype.precision = 32
+        self.assertEqual(dtype.precision, 32)
+
+        self.assertEqual(dtype.offset, 0)
+        dtype.offset = 2
+        self.assertEqual(dtype.offset, 2)
+        dtype.offset = 0
+        self.assertEqual(dtype.offset, 0)
+
+        order = dtype.order
+        self.assertTrue(dtype.order in [h5cpp.datatype.Order.LE,
+                                        h5cpp.datatype.Order.BE])
+        dtype.order = h5cpp.datatype.Order.BE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.BE)
+        dtype.order = h5cpp.datatype.Order.LE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.LE)
+        dtype.order = order
+
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ZERO)
+        self.assertEqual(mp, h5cpp.datatype.Pad.ZERO)
+        dtype.make_pad(h5cpp.datatype.Pad.ONE,
+                       h5cpp.datatype.Pad.BACKGROUND)
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ONE)
+        self.assertEqual(mp, h5cpp.datatype.Pad.BACKGROUND)
+        dtype.make_pad(h5cpp.datatype.Pad.ZERO,
+                       h5cpp.datatype.Pad.ZERO)
+
     def testInt32(self):
 
         dtype = h5cpp.datatype.kInt32
@@ -93,6 +253,38 @@ class PredefinedTypeTests(unittest.TestCase):
 
         dtype.make_signed(False)
         self.assertEqual(dtype.is_signed(), False)
+
+        self.assertEqual(dtype.precision, 32)
+        dtype.precision = 16
+        self.assertEqual(dtype.precision, 16)
+        dtype.precision = 32
+        self.assertEqual(dtype.precision, 32)
+
+        self.assertEqual(dtype.offset, 0)
+        dtype.offset = 2
+        self.assertEqual(dtype.offset, 2)
+        dtype.offset = 0
+        self.assertEqual(dtype.offset, 0)
+
+        order = dtype.order
+        self.assertTrue(dtype.order in [h5cpp.datatype.Order.LE,
+                                        h5cpp.datatype.Order.BE])
+        dtype.order = h5cpp.datatype.Order.BE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.BE)
+        dtype.order = h5cpp.datatype.Order.LE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.LE)
+        dtype.order = order
+
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ZERO)
+        self.assertEqual(mp, h5cpp.datatype.Pad.ZERO)
+        dtype.make_pad(h5cpp.datatype.Pad.ONE,
+                       h5cpp.datatype.Pad.BACKGROUND)
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ONE)
+        self.assertEqual(mp, h5cpp.datatype.Pad.BACKGROUND)
+        dtype.make_pad(h5cpp.datatype.Pad.ZERO,
+                       h5cpp.datatype.Pad.ZERO)
 
     def testUInt64(self):
 
@@ -104,6 +296,38 @@ class PredefinedTypeTests(unittest.TestCase):
         dtype.make_signed(True)
         self.assertEqual(dtype.is_signed(), True)
 
+        self.assertEqual(dtype.precision, 64)
+        dtype.precision = 32
+        self.assertEqual(dtype.precision, 32)
+        dtype.precision = 64
+        self.assertEqual(dtype.precision, 64)
+
+        self.assertEqual(dtype.offset, 0)
+        dtype.offset = 2
+        self.assertEqual(dtype.offset, 2)
+        dtype.offset = 0
+        self.assertEqual(dtype.offset, 0)
+
+        order = dtype.order
+        self.assertTrue(dtype.order in [h5cpp.datatype.Order.LE,
+                                        h5cpp.datatype.Order.BE])
+        dtype.order = h5cpp.datatype.Order.BE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.BE)
+        dtype.order = h5cpp.datatype.Order.LE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.LE)
+        dtype.order = order
+
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ZERO)
+        self.assertEqual(mp, h5cpp.datatype.Pad.ZERO)
+        dtype.make_pad(h5cpp.datatype.Pad.ONE,
+                       h5cpp.datatype.Pad.BACKGROUND)
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ONE)
+        self.assertEqual(mp, h5cpp.datatype.Pad.BACKGROUND)
+        dtype.make_pad(h5cpp.datatype.Pad.ZERO,
+                       h5cpp.datatype.Pad.ZERO)
+
     def testInt64(self):
 
         dtype = h5cpp.datatype.kInt64
@@ -113,6 +337,38 @@ class PredefinedTypeTests(unittest.TestCase):
 
         dtype.make_signed(False)
         self.assertEqual(dtype.is_signed(), False)
+
+        self.assertEqual(dtype.precision, 64)
+        dtype.precision = 32
+        self.assertEqual(dtype.precision, 32)
+        dtype.precision = 64
+        self.assertEqual(dtype.precision, 64)
+
+        self.assertEqual(dtype.offset, 0)
+        dtype.offset = 2
+        self.assertEqual(dtype.offset, 2)
+        dtype.offset = 0
+        self.assertEqual(dtype.offset, 0)
+
+        order = dtype.order
+        self.assertTrue(dtype.order in [h5cpp.datatype.Order.LE,
+                                        h5cpp.datatype.Order.BE])
+        dtype.order = h5cpp.datatype.Order.BE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.BE)
+        dtype.order = h5cpp.datatype.Order.LE
+        self.assertEqual(dtype.order, h5cpp.datatype.Order.LE)
+        dtype.order = order
+
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ZERO)
+        self.assertEqual(mp, h5cpp.datatype.Pad.ZERO)
+        dtype.make_pad(h5cpp.datatype.Pad.ONE,
+                       h5cpp.datatype.Pad.BACKGROUND)
+        lp, mp = dtype.pad()
+        self.assertEqual(lp, h5cpp.datatype.Pad.ONE)
+        self.assertEqual(mp, h5cpp.datatype.Pad.BACKGROUND)
+        dtype.make_pad(h5cpp.datatype.Pad.ZERO,
+                       h5cpp.datatype.Pad.ZERO)
 
     def testFloat32(self):
 


### PR DESCRIPTION
I resolves #94 but adding wrapper for precision, order, offset and  pad properties.